### PR TITLE
Rework private skins handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -72,7 +72,11 @@ The next metadata keys are usually filled
   - name - A name for the skin
   - author - The skin author
   - license - THe skin texture license
-  - assignment  - is "player:playername" in case the skin is assigned to be privat for a player
+  - assignment - (obsolete) is "player:playername" in case the skin is assigned to be privat for a player
+  - playername - Player assignment for private skin
 
 ## skin:get_meta_string(key)
 Same as get_meta() but does return "" instead of nil if the meta key does not exists
+
+## skin:is_applicable_for_player(playername)
+Check if a skin is applicable for the player "playername". Ususally the private skins could be applied to the player only

--- a/api.lua
+++ b/api.lua
@@ -7,18 +7,19 @@ end
 -- Assign skin to player
 function skins.assign_player_skin(player, skin)
 	local skin_obj
-	local skin_key
 	if type(skin) == "string" then
 		skin_obj = skins.get(skin) or skins.get(skins.default)
 	else
 		skin_obj = skin
 	end
-	skin_key = skin_obj:get_key()
 
-	if skin_key == skins.default then
-		skin_key = ""
+	if skin_obj:is_applicable_for_player(player:get_player_name()) then
+		local skin_key = skin_obj:get_key()
+		if skin_key == skins.default then
+			skin_key = ""
+		end
+		player:set_attribute("skinsdb:skin_key", skin_key)
 	end
-	player:set_attribute("skinsdb:skin_key", skin_key)
 end
 
 -- update visuals

--- a/sfinv_page.lua
+++ b/sfinv_page.lua
@@ -84,7 +84,7 @@ sfinv.register_page("skins:overview", {
 	title = "Skins",
 	get = function(self, player, context)
 		-- collect skins data
-		context.skins_list = skins.get_skinlist("player:"..player:get_player_name(), true)
+		context.skins_list = skins.get_skinlist_for_player(player:get_player_name())
 		context.total_pages = 1
 		for i, skin in ipairs(context.skins_list ) do
 			local page = math.floor((i-1) / 16)+1

--- a/skin_meta_api.lua
+++ b/skin_meta_api.lua
@@ -69,3 +69,8 @@ function skin_class:set_skin(player)
 		textures = {self:get_texture()},
 	})
 end
+
+function skin_class:is_applicable_for_player(playername)
+	local assigned_player = self:get_meta("playername")
+	return not assigned_player or assigned_player == playername
+end

--- a/skinlist.lua
+++ b/skinlist.lua
@@ -4,7 +4,7 @@ local skins_dir_list = minetest.get_dir_list(skins.modpath.."/textures")
 for _, fn in pairs(skins_dir_list) do
 	local nameparts = string.gsub(fn, "[.]", "_"):split("_")
 
-	local name, sort_id, assignment, is_preview
+	local name, sort_id, assignment, is_preview, playername
 	if nameparts[1] == "character" then
 		if tonumber(nameparts[2]) == nil then --default skin character.png
 			sort_id = 5000
@@ -16,8 +16,9 @@ for _, fn in pairs(skins_dir_list) do
 			is_preview = (nameparts[3] == "preview")
 		end
 	elseif nameparts[1] == "player" then
-		assignment = "player:"..nameparts[2]
+		assignment = "player:"..nameparts[2] --TODO: remove all assignment handling
 		name = "player_"..nameparts[2]
+		playername = nameparts[2]
 		if tonumber(nameparts[3]) then
 			sort_id = tonumber(nameparts[3])
 			is_preview = (nameparts[4] == "preview")
@@ -38,6 +39,9 @@ for _, fn in pairs(skins_dir_list) do
 			if assignment then
 				skin_obj:set_meta("assignment", assignment)
 			end
+			if playername then
+				skin_obj:set_meta("playername", playername)
+			end
 			local file = io.open(skins.modpath.."/meta/"..name..".txt", "r")
 			if file then
 				local data = string.split(file:read("*all"), "\n", 3)
@@ -52,13 +56,26 @@ for _, fn in pairs(skins_dir_list) do
 	end
 end
 
--- get skinlist. If assignment given ("mod:wardrobe" or "player:bell07") select skins matches the assignment. select_unassigned selects the skins without any assignment too
+-- (obsolete) get skinlist. If assignment given ("mod:wardrobe" or "player:bell07") select skins matches the assignment. select_unassigned selects the skins without any assignment too
 function skins.get_skinlist(assignment, select_unassigned)
+	minetest.log("deprecated", "skins.get_skinlist() is deprecated. Use skins.get_skinlist_for_player() instead")
 	local skinslist = {}
 	for _, skin in pairs(skins.meta) do
 		if not assignment or
 				assignment == skin:get_meta("assignment") or
 				(select_unassigned and skin:get_meta("assignment") == nil) then
+			table.insert(skinslist, skin)
+		end
+	end
+	table.sort(skinslist, function(a,b) return a:get_meta("_sort_id") < b:get_meta("_sort_id") end)
+	return skinslist
+end
+
+-- Get skinlist for player. If no player given, public skins only selected
+function skins.get_skinlist_for_player(playername)
+	local skinslist = {}
+	for _, skin in pairs(skins.meta) do
+		if skin:is_applicable_for_player(playername) then
 			table.insert(skinslist, skin)
 		end
 	end

--- a/unified_inventory_page.lua
+++ b/unified_inventory_page.lua
@@ -7,7 +7,7 @@ end
 
 local dropdown_values = {}
 local skins_reftab = {}
-local skins_list = skins.get_skinlist()
+local skins_list = skins.get_skinlist_for_player() --public only
 unified_inventory.register_page("skins", {
 	get_formspec = function(player)
 		local name = player:get_player_name()


### PR DESCRIPTION
 -add skin:is_applicable_for_player(playername) method
- hide private skins in unified_inventory since not supported (#1)
- check player assignment in skins.assign_player_skin() + inherited to skins.set_player_skin() (bug-part in #1)
