### PR TITLE
UI improvements

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,6 +5,7 @@ Return the skin object assigned to the player. Returns defaout if nothins assign
 
 ## skins.assign_player_skin(player, skin)
 Select the skin for the player. The "skin" parameter could be the skin key or the skin object
+Returns false if skin is not valid or applicable to player
 
 ## skins.update_player_skin(player)
 Update selected skin visuals on player

--- a/api.lua
+++ b/api.lua
@@ -8,9 +8,13 @@ end
 function skins.assign_player_skin(player, skin)
 	local skin_obj
 	if type(skin) == "string" then
-		skin_obj = skins.get(skin) or skins.get(skins.default)
+		skin_obj = skins.get(skin)
 	else
 		skin_obj = skin
+	end
+
+	if not skin_obj then
+		return false
 	end
 
 	if skin_obj:is_applicable_for_player(player:get_player_name()) then
@@ -19,7 +23,10 @@ function skins.assign_player_skin(player, skin)
 			skin_key = ""
 		end
 		player:set_attribute("skinsdb:skin_key", skin_key)
+	else
+		return false
 	end
+	return true
 end
 
 -- update visuals
@@ -30,6 +37,9 @@ end
 
 -- Assign and update
 function skins.set_player_skin(player, skin)
-	skins.assign_player_skin(player, skin)
-	skins.update_player_skin(player)
+	local success = skins.assign_player_skin(player, skin)
+	if success then
+		skins.update_player_skin(player)
+	end
+	return success
 end

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -1,5 +1,5 @@
 minetest.register_chatcommand("skinsdb", {
-	params = "[set] <skinname> | list | list private | list public",
+	params = "[set] <skin key> | show [<skin key>] | list | list private | list public",
 	description = "Set, show or list player's skin",
 	func = function(name, param)
 		local player = minetest.get_player_by_name(name)
@@ -12,7 +12,7 @@ minetest.register_chatcommand("skinsdb", {
 		for word in param:gmatch("([^ ]+)") do
 			if not command then
 				-- first word
-				if word == 'set' or word == 'list' then
+				if word == 'set' or word == 'list' or word == 'show' then
 					command = word
 				elseif skins.get(word) then
 					command = 'set'
@@ -58,6 +58,17 @@ minetest.register_chatcommand("skinsdb", {
 				end
 				minetest.chat_send_player(name, info)
 			end
+		elseif command == "show" then
+			if parameter then
+				skin = skins.get(parameter)
+			else
+				skin = skins.get_player_skin(player)
+			end
+			if not skin then
+				return false, "unknown skin"
+			end
+			local formspec = "size[8,3]"..skins.get_skin_info_formspec(skin)
+			minetest.show_formspec(name, 'skinsdb_show_skin', formspec)
 		end
 
 

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -1,0 +1,65 @@
+minetest.register_chatcommand("skinsdb", {
+	params = "[set] <skinname> | list | list private | list public",
+	description = "Set, show or list player's skin",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return false, "Player not found"
+		end
+
+		-- parse command line
+		local command, parameter
+		for word in param:gmatch("([^ ]+)") do
+			if not command then
+				-- first word
+				if word == 'set' or word == 'list' then
+					command = word
+				elseif skins.get(word) then
+					command = 'set'
+					parameter = word
+					break
+				else
+					return false, "unknown command "..word.." see /help skinsdb for supported parameters"
+				end
+			else
+				-- second word
+				parameter = word
+				break
+			end
+		end
+		if not command then
+			return false, "see /help skinsdb for supported parameters"
+		end
+
+		if command == "set" then
+			local success = skins.set_player_skin(player, parameter)
+			if success then
+				return true, "skin set to "..parameter
+			else
+				return false, "invalid skin "..parameter
+			end
+		elseif command == "list" then
+			local list
+			if parameter == "private" then
+				list = skins.get_skinlist_with_meta("playername", name)
+			elseif parameter == "public" then
+				list = skins.get_skinlist_for_player()
+			elseif not parameter then
+				list = skins.get_skinlist_for_player(name)
+			else
+				return false, "unknown parameter", parameter
+			end
+
+			local current_skin_key = skins.get_player_skin(player):get_key()
+			for _, skin in ipairs(list) do
+				local info = skin:get_key()..": name="..skin:get_meta("name").." author="..skin:get_meta("author").." license="..skin:get_meta("license")
+				if skin:get_key() == current_skin_key then
+					info = minetest.colorize("#00FFFF", info)
+				end
+				minetest.chat_send_player(name, info)
+			end
+		end
+
+
+	end,
+})

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -1,10 +1,9 @@
-local function show_selection_formspec(player, context)
-	skins.rebuild_formspec_context(player, context)
+local function show_selection_formspec(player)
+	local context = skins.ui_context[player:get_player_name()]
 	local name = player:get_player_name()
 	local skin = skins.get_player_skin(player)
 	local formspec = "size[8,8]"..skins.get_skin_info_formspec(skin)
-	formspec = formspec..skins.get_skin_selection_formspec(context, 3.5)
-	player:set_attribute('skinsdb_context', minetest.serialize(context))
+	formspec = formspec..skins.get_skin_selection_formspec(player, context, 3.5)
 	minetest.show_formspec(name, 'skinsdb_show_ui', formspec)
 end
 
@@ -82,8 +81,7 @@ minetest.register_chatcommand("skinsdb", {
 			local formspec = "size[8,3]"..skins.get_skin_info_formspec(skin)
 			minetest.show_formspec(name, 'skinsdb_show_skin', formspec)
 		elseif command == "ui" then
-			local context = minetest.deserialize(player:get_attribute('skinsdb_context')) or {}
-			show_selection_formspec(player, context)
+			show_selection_formspec(player)
 		end
 	end,
 })
@@ -94,17 +92,12 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		return
 	end
 
-	local context = minetest.deserialize(player:get_attribute('skinsdb_context'))
-	if not context then
-		return
-	end
+	local context = skins.ui_context[player:get_player_name()]
 
 	local action = skins.on_skin_selection_receive_fields(player, context, fields)
 	if action == 'set' then
-		player:set_attribute('skinsdb_context',"")
 		minetest.close_formspec(player:get_player_name(), formname)
 	elseif action == 'page' then
-		player:set_attribute('skinsdb_context', minetest.serialize(context))
-		show_selection_formspec(player, context)
+		show_selection_formspec(player)
 	end
 end)

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -52,7 +52,7 @@ minetest.register_chatcommand("skinsdb", {
 
 			local current_skin_key = skins.get_player_skin(player):get_key()
 			for _, skin in ipairs(list) do
-				local info = skin:get_key()..": name="..skin:get_meta("name").." author="..skin:get_meta("author").." license="..skin:get_meta("license")
+				local info = skin:get_key()..": name="..skin:get_meta_string("name").." author="..skin:get_meta_string("author").." license="..skin:get_meta_string("license")
 				if skin:get_key() == current_skin_key then
 					info = minetest.colorize("#00FFFF", info)
 				end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -1,5 +1,23 @@
 local S = skins.S
 
+
+-- Prepare server-site state / context
+function skins.rebuild_formspec_context(player, context)
+	local skin = skins.get_player_skin(player)
+	context.skins_list = skins.get_skinlist_for_player(player:get_player_name())
+	context.total_pages = 1
+	for i, skin in ipairs(context.skins_list ) do
+		local page = math.floor((i-1) / 16)+1
+		skin:set_meta("inv_page", page)
+		skin:set_meta("inv_page_index", (i-1)%16+1)
+		context.total_pages = page
+	end
+	context.skins_page = context.skins_page or skin:get_meta("inv_page")
+	context.dropdown_values = nil
+	return context
+end
+
+
 -- Show skin info
 function skins.get_skin_info_formspec(skin)
 	local texture = skin:get_texture()
@@ -22,4 +40,71 @@ function skins.get_skin_info_formspec(skin)
 		formspec = formspec.."label[2,1.5;"..S("License")..": "..minetest.formspec_escape(m_license).."]"
 	end
 	return formspec
+end
+
+function skins.get_skin_selection_formspec(context, y_delta)
+	local page = context.skins_page or 1
+	local formspec = ""
+	for i = (page-1)*16+1, page*16 do
+		local skin = context.skins_list[i]
+		if not skin then
+			break
+		end
+
+		local index_p = skin:get_meta("inv_page_index")
+		local x = (index_p-1) % 8
+		local y
+		if index_p > 8 then
+			y = y_delta + 1.9
+		else
+			y = y_delta
+		end
+		formspec = formspec.."image_button["..x..","..y..";1,2;"..
+			skin:get_preview()..";skins_set$"..i..";]"..
+			"tooltip[skins_set$"..i..";"..minetest.formspec_escape(skin:get_meta_string("name")).."]"
+	end
+
+	if context.total_pages > 1 then
+		local page_prev = page - 1
+		local page_next = page + 1
+		if page_prev < 1 then
+			page_prev = context.total_pages
+		end
+		if page_next > context.total_pages then
+			page_next = 1
+		end
+		local page_list = ""
+		context.dropdown_values = {}
+		for pg=1, context.total_pages do
+			local pagename = S("Page").." "..pg.."/"..context.total_pages
+			context.dropdown_values[pagename] = pg
+			if pg > 1 then page_list = page_list.."," end
+			page_list = page_list..pagename
+		end
+		formspec = formspec
+			.."button[0,"..(y_delta+4.0)..";1,.5;skins_page$"..page_prev..";<<]"
+			.."dropdown[0.9,"..(y_delta+3.88)..";6.5,.5;skins_selpg;"..page_list..";"..page.."]"
+			.."button[7,"..(y_delta+4.0)..";1,.5;skins_page$"..page_next..";>>]"
+	end
+	return formspec
+end
+
+function skins.on_skin_selection_receive_fields(player, context, fields)
+	for field, _ in pairs(fields) do
+		local current = string.split(field, "$", 2)
+		if current[1] == "skins_set" then
+			local selected_skin = context.skins_list[tonumber(current[2])]
+			setmetatable(selected_skin, skins.skin_class)
+
+			skins.set_player_skin(player, selected_skin)
+			return 'set'
+		elseif current[1] == "skins_page" then
+			context.skins_page = tonumber(current[2])
+			return 'page'
+		end
+	end
+	if fields.skins_selpg then
+		context.skins_page = tonumber(context.dropdown_values[fields.skins_selpg])
+		return 'page'
+	end
 end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -1,23 +1,5 @@
 local S = skins.S
 
-
--- Prepare server-site state / context
-function skins.rebuild_formspec_context(player, context)
-	local skin = skins.get_player_skin(player)
-	context.skins_list = skins.get_skinlist_for_player(player:get_player_name())
-	context.total_pages = 1
-	for i, skin in ipairs(context.skins_list ) do
-		local page = math.floor((i-1) / 16)+1
-		skin:set_meta("inv_page", page)
-		skin:set_meta("inv_page_index", (i-1)%16+1)
-		context.total_pages = page
-	end
-	context.skins_page = context.skins_page or skin:get_meta("inv_page")
-	context.dropdown_values = nil
-	return context
-end
-
-
 -- Show skin info
 function skins.get_skin_info_formspec(skin)
 	local texture = skin:get_texture()
@@ -43,8 +25,18 @@ function skins.get_skin_info_formspec(skin)
 end
 
 function skins.get_skin_selection_formspec(player, context, y_delta)
-	skins.rebuild_formspec_context(player, context)
-	local page = context.skins_page or 1
+	context.skins_list = skins.get_skinlist_for_player(player:get_player_name())
+	context.total_pages = 1
+	for i, skin in ipairs(context.skins_list ) do
+		local page = math.floor((i-1) / 16)+1
+		skin:set_meta("inv_page", page)
+		skin:set_meta("inv_page_index", (i-1)%16+1)
+		context.total_pages = page
+	end
+	context.skins_page = context.skins_page or skins.get_player_skin(player):get_meta("inv_page") or 1
+	context.dropdown_values = nil
+
+	local page = context.skins_page
 	local formspec = ""
 	for i = (page-1)*16+1, page*16 do
 		local skin = context.skins_list[i]

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -1,0 +1,25 @@
+local S = skins.S
+
+-- Show skin info
+function skins.get_skin_info_formspec(skin)
+	local texture = skin:get_texture()
+	local m_name = skin:get_meta_string("name")
+	local m_author = skin:get_meta_string("author")
+	local m_license = skin:get_meta_string("license")
+	-- overview page
+	local formspec = "image[0,.75;1,2;"..skin:get_preview().."]"
+	if texture then
+		formspec = formspec.."label[6,.5;"..S("Raw texture")..":]"
+		.."image[6,1;2,1;"..skin:get_texture().."]"
+	end
+	if m_name ~= "" then
+		formspec = formspec.."label[2,.5;"..S("Name")..": "..minetest.formspec_escape(m_name).."]"
+	end
+	if m_author ~= "" then
+		formspec = formspec.."label[2,1;"..S("Author")..": "..minetest.formspec_escape(m_author).."]"
+	end
+	if m_license ~= "" then
+		formspec = formspec.."label[2,1.5;"..S("License")..": "..minetest.formspec_escape(m_license).."]"
+	end
+	return formspec
+end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -42,7 +42,8 @@ function skins.get_skin_info_formspec(skin)
 	return formspec
 end
 
-function skins.get_skin_selection_formspec(context, y_delta)
+function skins.get_skin_selection_formspec(player, context, y_delta)
+	skins.rebuild_formspec_context(player, context)
 	local page = context.skins_page or 1
 	local formspec = ""
 	for i = (page-1)*16+1, page*16 do
@@ -93,10 +94,7 @@ function skins.on_skin_selection_receive_fields(player, context, fields)
 	for field, _ in pairs(fields) do
 		local current = string.split(field, "$", 2)
 		if current[1] == "skins_set" then
-			local selected_skin = context.skins_list[tonumber(current[2])]
-			setmetatable(selected_skin, skins.skin_class)
-
-			skins.set_player_skin(player, selected_skin)
+			skins.set_player_skin(player, context.skins_list[tonumber(current[2])])
 			return 'set'
 		elseif current[1] == "skins_page" then
 			context.skins_page = tonumber(current[2])

--- a/init.lua
+++ b/init.lua
@@ -44,6 +44,12 @@ if minetest.global_exists("armor") then
 end
 
 -- Update skin on join
+skins.ui_context = {}
 minetest.register_on_joinplayer(function(player)
 	skins.update_player_skin(player)
+	skins.ui_context[player:get_player_name()] = {}
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	skins.ui_context[player:get_player_name()] = nil
 end)

--- a/init.lua
+++ b/init.lua
@@ -9,9 +9,18 @@ skins = {}
 skins.modpath = minetest.get_modpath(minetest.get_current_modname())
 skins.default = "character"
 
+local S
+if minetest.get_modpath("intllib") then
+	skins.S = intllib.Getter()
+else
+	skins.S = function(s) return s end
+end
+
+
 dofile(skins.modpath.."/skin_meta_api.lua")
 dofile(skins.modpath.."/api.lua")
 dofile(skins.modpath.."/skinlist.lua")
+dofile(skins.modpath.."/formspecs.lua")
 dofile(skins.modpath.."/chatcommands.lua")
 -- Unified inventory page/integration
 if minetest.get_modpath("unified_inventory") then

--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ skins.default = "character"
 dofile(skins.modpath.."/skin_meta_api.lua")
 dofile(skins.modpath.."/api.lua")
 dofile(skins.modpath.."/skinlist.lua")
-
+dofile(skins.modpath.."/chatcommands.lua")
 -- Unified inventory page/integration
 if minetest.get_modpath("unified_inventory") then
 	dofile(skins.modpath.."/unified_inventory_page.lua")

--- a/sfinv_page.lua
+++ b/sfinv_page.lua
@@ -2,58 +2,9 @@ local S = skins.S
 
 -- generate the current formspec
 local function get_formspec(player, context)
-	local name = player:get_player_name()
 	local skin = skins.get_player_skin(player)
 	local formspec = skins.get_skin_info_formspec(skin)
-
-	local page = 1
-	if context.skins_page then
-		page = context.skins_page 
-	else
-		page = skin:get_meta("inv_page") or 1
-	end
-
-	for i = (page-1)*16+1, page*16 do
-		local skin = context.skins_list[i]
-		if not skin then
-			break
-		end
-
-		local index_p = skin:get_meta("inv_page_index")
-		local x = (index_p-1) % 8
-		local y
-		if index_p > 8 then
-			y = 5.5
-		else
-			y = 3.2
-		end
-		formspec = formspec.."image_button["..x..","..y..";1,2;"..
-			skin:get_preview()..";skins_set$"..i..";]"..
-			"tooltip[skins_set$"..i..";"..minetest.formspec_escape(skin:get_meta_string("name")).."]"
-	end
-
-	if context.total_pages > 1 then
-		local page_prev = page - 1
-		local page_next = page + 1
-		if page_prev < 1 then
-			page_prev = context.total_pages
-		end
-		if page_next > context.total_pages then
-			page_next = 1
-		end
-		local page_list = ""
-		context.dropdown_values = {}
-		for pg=1, context.total_pages do
-			local pagename = S("Page").." "..pg.."/"..context.total_pages
-			context.dropdown_values[pagename] = pg
-			if pg > 1 then page_list = page_list.."," end
-			page_list = page_list..pagename
-		end
-		formspec = formspec
-			.."button[0,8.3;1,.5;skins_page$"..page_prev..";<<]"
-			.."dropdown[1,8.16;6.5,.5;skins_selpg;"..page_list..";"..page.."]"
-			.."button[7,8.3;1,.5;skins_page$"..page_next..";>>]"
-	end
+	formspec = formspec..skins.get_skin_selection_formspec(context, 4)
 	return formspec
 end
 
@@ -61,34 +12,11 @@ sfinv.register_page("skins:overview", {
 	title = "Skins",
 	get = function(self, player, context)
 		-- collect skins data
-		context.skins_list = skins.get_skinlist_for_player(player:get_player_name())
-		context.total_pages = 1
-		for i, skin in ipairs(context.skins_list ) do
-			local page = math.floor((i-1) / 16)+1
-			skin:set_meta("inv_page", page)
-			skin:set_meta("inv_page_index", (i-1)%16+1)
-			context.total_pages = page
-		end
-		-- generate first formspec
+		context = skins.rebuild_formspec_context(player, context)
 		return sfinv.make_formspec(player, context, get_formspec(player, context))
 	end,
 	on_player_receive_fields = function(self, player, context, fields)
-		for field, _ in pairs(fields) do
-			local current = string.split(field, "$", 2)
-			if current[1] == "skins_set" then
-				skins.set_player_skin(player, context.skins_list[tonumber(current[2])])
-				sfinv.set_player_inventory_formspec(player)
-				return
-			elseif current[1] == "skins_page" then
-				context.skins_page = tonumber(current[2])
-				sfinv.set_player_inventory_formspec(player)
-				return
-			end
-		end
-		if fields.skins_selpg then
-			context.skins_page = tonumber(context.dropdown_values[fields.skins_selpg])
-			sfinv.set_player_inventory_formspec(player)
-			return
-		end
+		skins.on_skin_selection_receive_fields(player, context, fields)
+		sfinv.set_player_inventory_formspec(player)
 	end
 })

--- a/sfinv_page.lua
+++ b/sfinv_page.lua
@@ -4,7 +4,7 @@ local S = skins.S
 local function get_formspec(player, context)
 	local skin = skins.get_player_skin(player)
 	local formspec = skins.get_skin_info_formspec(skin)
-	formspec = formspec..skins.get_skin_selection_formspec(context, 4)
+	formspec = formspec..skins.get_skin_selection_formspec(player, context, 4)
 	return formspec
 end
 
@@ -12,7 +12,6 @@ sfinv.register_page("skins:overview", {
 	title = "Skins",
 	get = function(self, player, context)
 		-- collect skins data
-		context = skins.rebuild_formspec_context(player, context)
 		return sfinv.make_formspec(player, context, get_formspec(player, context))
 	end,
 	on_player_receive_fields = function(self, player, context, fields)

--- a/sfinv_page.lua
+++ b/sfinv_page.lua
@@ -1,33 +1,10 @@
-local S
-if minetest.get_modpath("intllib") then
-	S = intllib.Getter()
-else
-	S = function(s) return s end
-end
+local S = skins.S
 
 -- generate the current formspec
 local function get_formspec(player, context)
 	local name = player:get_player_name()
 	local skin = skins.get_player_skin(player)
-	local texture = skin:get_texture()
-	local m_name = skin:get_meta_string("name")
-	local m_author = skin:get_meta_string("author")
-	local m_license = skin:get_meta_string("license")
-	-- overview page
-	local formspec = "image[0,.75;1,2;"..skin:get_preview().."]"
-	if texture then
-		formspec = formspec.."label[6,.5;"..S("Raw texture")..":]"
-		.."image[6,1;2,1;"..skin:get_texture().."]"
-	end
-	if m_name ~= "" then
-		formspec = formspec.."label[2,.5;"..S("Name")..": "..minetest.formspec_escape(m_name).."]"
-	end
-	if m_author ~= "" then
-		formspec = formspec.."label[2,1;"..S("Author")..": "..minetest.formspec_escape(m_author).."]"
-	end
-	if m_license ~= "" then
-		formspec = formspec.."label[2,1.5;"..S("License")..": "..minetest.formspec_escape(m_license).."]"
-	end
+	local formspec = skins.get_skin_info_formspec(skin)
 
 	local page = 1
 	if context.skins_page then

--- a/skin_meta_api.lua
+++ b/skin_meta_api.lua
@@ -2,6 +2,7 @@ skins.meta = {}
 
 local skin_class = {}
 skin_class.__index = skin_class
+skins.skin_class = skin_class
 -----------------------
 -- Class methods
 -----------------------

--- a/unified_inventory_page.lua
+++ b/unified_inventory_page.lua
@@ -15,12 +15,9 @@ unified_inventory.register_button("skins", {
 })
 
 local function get_formspec(player)
-	-- unified inventory is stateless, but skins pager needs some context usage to be more flexible
-	local context = minetest.deserialize(player:get_attribute('skinsdb_unified_inventory_context')) or {}
-	context = skins.rebuild_formspec_context(player, context)
+	local context = skins.ui_context[player:get_player_name()]
 	local formspec = "background[0.06,0.99;7.92,7.52;ui_misc_form.png]"..
-			skins.get_skin_selection_formspec(context, -0.2)
-	player:set_attribute('skinsdb_unified_inventory_context', minetest.serialize(context))
+			skins.get_skin_selection_formspec(player, context, -0.2)
 	return formspec
 end
 
@@ -33,7 +30,6 @@ unified_inventory.register_page("skins_page", {
 -- click button handlers
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if fields.skins then
-		player:set_attribute('skinsdb_unified_inventory_context',"") --reset context
 		unified_inventory.set_inventory_formspec(player, "craft")
 		return
 	end
@@ -42,23 +38,11 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		return
 	end
 
-	local context -- read context only if skins related action
-	for field, _ in pairs(fields) do
-		if field:sub(1,5) == "skins" then
-			context = minetest.deserialize(player:get_attribute('skinsdb_unified_inventory_context')) or {}
-			break
-		end
-	end
-	if not context then
-		return
-	end
-
+	local context = skins.ui_context[player:get_player_name()]
 	local action = skins.on_skin_selection_receive_fields(player, context, fields)
 	if action == 'set' then
-		player:set_attribute('skinsdb_unified_inventory_context',"") --reset context
 		unified_inventory.set_inventory_formspec(player, "skins")
 	elseif action == 'page' then
-		player:set_attribute('skinsdb_unified_inventory_context', minetest.serialize(context))
 		unified_inventory.set_inventory_formspec(player, "skins_page")
 	end
 end)

--- a/unified_inventory_page.lua
+++ b/unified_inventory_page.lua
@@ -38,6 +38,10 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		return
 	end
 
+	if formname ~= "" then
+		return
+	end
+
 	local context -- read context only if skins related action
 	for field, _ in pairs(fields) do
 		if field:sub(1,5) == "skins" then

--- a/unified_inventory_page.lua
+++ b/unified_inventory_page.lua
@@ -1,38 +1,14 @@
-local S
-if minetest.get_modpath("intllib") then
-	S = intllib.Getter()
-else
-	S = function(s) return s end
-end
+local S = skins.S
 
 local dropdown_values = {}
 local skins_reftab = {}
 local skins_list = skins.get_skinlist_for_player() --public only
 unified_inventory.register_page("skins", {
 	get_formspec = function(player)
-		local name = player:get_player_name()
 		local skin = skins.get_player_skin(player)
-		local texture = skin:get_texture()
-		local m_name = skin:get_meta_string("name")
-		local m_author = skin:get_meta_string("author")
-		local m_license = skin:get_meta_string("license")
-		local formspec = "background[0.06,0.99;7.92,7.52;ui_misc_form.png]".."image[0,.75;1,2;"..skin:get_preview().."]"
-		if texture then
-			formspec=formspec.."label[6,.5;"..S("Raw texture")..":]"
-			.."image[6,1;2,1;"..texture.."]"
-		end
-		if m_name ~= "" then
-			formspec = formspec.."label[2,.5;"..S("Name")..": "..minetest.formspec_escape(m_name).."]"
-		end
-		if m_author ~= "" then
-			formspec = formspec.."label[2,1;"..S("Author")..": "..minetest.formspec_escape(m_author).."]"
-		end
-		if m_license ~= "" then
-			formspec = formspec.."label[2,1.5;"..S("License")..": "..minetest.formspec_escape(m_license).."]"
-		end
-
 		local page = skin:get_meta("inv_page") or 1
-		formspec = formspec .. "button[.75,3;6.5,.5;skins_page$"..page..";"..S("Change").."]"
+		local formspec = "background[0.06,0.99;7.92,7.52;ui_misc_form.png]"..skins.get_skin_info_formspec(skin)..
+				"button[.75,3;6.5,.5;skins_page$"..page..";"..S("Change").."]"
 		return {formspec=formspec}
 	end,
 })

--- a/unified_inventory_page.lua
+++ b/unified_inventory_page.lua
@@ -1,14 +1,10 @@
 local S = skins.S
 
-local dropdown_values = {}
-local skins_reftab = {}
-local skins_list = skins.get_skinlist_for_player() --public only
 unified_inventory.register_page("skins", {
 	get_formspec = function(player)
 		local skin = skins.get_player_skin(player)
-		local page = skin:get_meta("inv_page") or 1
 		local formspec = "background[0.06,0.99;7.92,7.52;ui_misc_form.png]"..skins.get_skin_info_formspec(skin)..
-				"button[.75,3;6.5,.5;skins_page$"..page..";"..S("Change").."]"
+				"button[.75,3;6.5,.5;skins_page;"..S("Change").."]"
 		return {formspec=formspec}
 	end,
 })
@@ -18,85 +14,47 @@ unified_inventory.register_button("skins", {
 	image = "skins_button.png",
 })
 
--- Create all of the skin-picker pages.
-local total_pages = 1
-for i, skin in ipairs(skins_list) do
-	local page = math.floor((i-1) / 16)+1
-	skin:set_meta("inv_page", page)
-	skin:set_meta("inv_page_index", (i-1)%16+1)
-	total_pages = page
+local function get_formspec(player)
+	-- unified inventory is stateless, but skins pager needs some context usage to be more flexible
+	local context = minetest.deserialize(player:get_attribute('skinsdb_unified_inventory_context')) or {}
+	context = skins.rebuild_formspec_context(player, context)
+	local formspec = "background[0.06,0.99;7.92,7.52;ui_misc_form.png]"..
+			skins.get_skin_selection_formspec(context, -0.2)
+	player:set_attribute('skinsdb_unified_inventory_context', minetest.serialize(context))
+	return formspec
 end
 
-for page=1, total_pages do
-	local formspec = "background[0.06,0.99;7.92,7.52;ui_misc_form.png]"
-	for i = (page-1)*16+1, page*16 do
-		local skin = skins_list[i]
-		if not skin then
-			break
-		end
-
-		local index_p = skin:get_meta("inv_page_index")
-		local x = (index_p-1) % 8
-		local y
-		if index_p > 8 then
-			y = 1.8
-		else
-			y = -0.1
-		end
-		formspec = (formspec.."image_button["..x..","..y..";1,2;"..
-			skin:get_preview()..";skins_set$"..i..";]"..
-			"tooltip[skins_set$"..i..";"..minetest.formspec_escape(skin:get_meta_string("name")).."]")
+unified_inventory.register_page("skins_page", {
+	get_formspec = function(player)
+		return {formspec=get_formspec(player)}
 	end
-	if total_pages > 1 then
-		local page_prev = page - 1
-		local page_next = page + 1
-		if page_prev < 1 then
-			page_prev = total_pages
-		end
-		if page_next > total_pages then
-			page_next = 1
-		end
-		local page_list = ""
-		dropdown_values = {}
-		for pg=1, total_pages do
-			local pagename = S("Page").." "..pg.."/"..total_pages
-			dropdown_values[pagename] = pg
-			if pg > 1 then page_list = page_list.."," end
-			page_list = page_list..pagename
-		end
-		formspec = (formspec
-			.."button[0,3.8;1,.5;skins_page$"..page_prev..";<<]"
-			.."dropdown[1,3.68;6.5,.5;skins_selpg;"..page_list..";"..page.."]"
-			.."button[7,3.8;1,.5;skins_page$"..page_next..";>>]")
-	end
-	unified_inventory.register_page("skins_page$"..(page), {
-		get_formspec = function(player)
-			return {formspec=formspec}
-		end
-	})
-end
-
+})
 
 -- click button handlers
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if fields.skins then
+		player:set_attribute('skinsdb_unified_inventory_context',"") --reset context
 		unified_inventory.set_inventory_formspec(player, "craft")
 		return
 	end
+
+	local context -- read context only if skins related action
 	for field, _ in pairs(fields) do
-		local current = string.split(field, "$", 2)
-		if current[1] == "skins_set" then
-			skins.set_player_skin(player, skins_list[tonumber(current[2])])
-			unified_inventory.set_inventory_formspec(player, "skins")
-			return
-		elseif current[1] == "skins_page" then
-			unified_inventory.set_inventory_formspec(player, "skins_page$"..current[2])
-			return
+		if field:sub(1,5) == "skins" then
+			context = minetest.deserialize(player:get_attribute('skinsdb_unified_inventory_context')) or {}
+			break
 		end
 	end
-	if fields.skins_selpg then
-		local page = dropdown_values[fields.skins_selpg]
-		unified_inventory.set_inventory_formspec(player, "skins_page$"..(page))
+	if not context then
 		return
+	end
+
+	local action = skins.on_skin_selection_receive_fields(player, context, fields)
+	if action == 'set' then
+		player:set_attribute('skinsdb_unified_inventory_context',"") --reset context
+		unified_inventory.set_inventory_formspec(player, "skins")
+	elseif action == 'page' then
+		player:set_attribute('skinsdb_unified_inventory_context', minetest.serialize(context))
+		unified_inventory.set_inventory_formspec(player, "skins_page")
 	end
 end)


### PR DESCRIPTION
 - Includes previous PR #5 for issue #2
 - formspec parts consolidated to formspec.lua removing redundancy
 - unified_inventory supports private skins now, fixes #3 
 - new chat command /skinsdb show to show current skin info in a formspec
 - new chat command `/skinsdb show` to show skin info in a formspec
 - new chat command `/skinsdb ui` (or just /skinsdb) to show select skin in formspec without inventory