### PR TITLE
Bugfix #8 Create and get UI-context on demand

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -1,7 +1,7 @@
 local S = skins.S
 
 local function show_selection_formspec(player)
-	local context = skins.ui_context[player:get_player_name()]
+	local context = skins.get_formspec_context(player)
 	local name = player:get_player_name()
 	local skin = skins.get_player_skin(player)
 	local formspec = "size[8,8]"..skins.get_skin_info_formspec(skin)
@@ -89,7 +89,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		return
 	end
 
-	local context = skins.ui_context[player:get_player_name()]
+	local context = skins.get_formspec_context(player)
 
 	local action = skins.on_skin_selection_receive_fields(player, context, fields)
 	if action == 'set' then

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -1,5 +1,15 @@
 local S = skins.S
 
+function skins.get_formspec_context(player)
+	if player then
+		local playername = player:get_player_name()
+		skins.ui_context[playername] = skins.ui_context[playername] or {}
+		return skins.ui_context[playername]
+	else
+		return {}
+	end
+end
+
 -- Show skin info
 function skins.get_skin_info_formspec(skin)
 	local texture = skin:get_texture()

--- a/init.lua
+++ b/init.lua
@@ -47,7 +47,6 @@ end
 skins.ui_context = {}
 minetest.register_on_joinplayer(function(player)
 	skins.update_player_skin(player)
-	skins.ui_context[player:get_player_name()] = {}
 end)
 
 minetest.register_on_leaveplayer(function(player)

--- a/unified_inventory_page.lua
+++ b/unified_inventory_page.lua
@@ -15,7 +15,7 @@ unified_inventory.register_button("skins", {
 })
 
 local function get_formspec(player)
-	local context = skins.ui_context[player:get_player_name()]
+	local context = skins.get_formspec_context(player)
 	local formspec = "background[0.06,0.99;7.92,7.52;ui_misc_form.png]"..
 			skins.get_skin_selection_formspec(player, context, -0.2)
 	return formspec
@@ -38,7 +38,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		return
 	end
 
-	local context = skins.ui_context[player:get_player_name()]
+	local context = skins.get_formspec_context(player)
 	local action = skins.on_skin_selection_receive_fields(player, context, fields)
 	if action == 'set' then
 		unified_inventory.set_inventory_formspec(player, "skins")


### PR DESCRIPTION
Should solve the Issue #8 

If UE does call the register_on_joinplayer  before skinsdb the context table is created on demand now