### PR TITLE
Compare player assignment non case sensitive

### DIFF
--- a/skin_meta_api.lua
+++ b/skin_meta_api.lua
@@ -73,7 +73,6 @@ end
 
 function skin_class:is_applicable_for_player(playername)
 	local assigned_player = self:get_meta("playername")
-	return assigned_player == nil or
-			assigned_player == playername or
-			assigned_player == true
+	return assigned_player == nil or assigned_player == true or
+			(assigned_player:lower() == playername:lower())
 end


### PR DESCRIPTION
Minetest does not allow multiple players with same name but different case (bell07 vs. Bell07). Therefore the skin player assignment can ignore the case so "player_bell07.png" is visible for Bell07 player.

