### PR TITLE
Visual update fixes if skin change externally

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,20 +1,17 @@
 # Skinsdb Interface
 
 ## skins.get_player_skin(player)
-Return the skin object assigned to the player. Returns defaout if nothins assigned
+Return the skin object assigned to the player. Returns default if nothing assigned
 
 ## skins.assign_player_skin(player, skin)
-Select the skin for the player. The "skin" parameter could be the skin key or the skin object
+Check if allowed and assign the skin for the player without visual updates. The "skin" parameter could be the skin key or the skin object
 Returns false if skin is not valid or applicable to player
 
 ## skins.update_player_skin(player)
 Update selected skin visuals on player
 
 ## skins.set_player_skin(player, skin)
-```
-skins.assign_player_skin(player, skin)
-skins.update_player_skin(player)
-```
+Function for external usage on skin selection. This function assign the skin, call the skin:set_skin(player) hook to update dynamic skins, then update the visuals
 
 ## skins.get_skin_format(file)
 Returns the skin format version ("1.0" or "1.8"). File is an open file handle to the texture file
@@ -67,11 +64,11 @@ Get the skin preview
 Could be redefined for dynamic preview texture generation
 
 ## skin:set_skin(player)
-Apply the skin to the player and do some resets.
-Is called if skin selection started, in skins.update_player_skin() for examlpe
+Hook for dynamic skins updates on select. Is called in skins.set_player_skin()
+In skinsdb the default implementation for this function is empty.
 
 skin:apply_skin_to_player(player)
-Apply the skin to the player. Is called in set_skin() and other places the skin needs to be updated
+Apply the skin to the player. Called in skins.update_player_skin() to update visuals
 
 ## skin:set_meta(key, value)
 Add a meta information to the skin object

--- a/api.lua
+++ b/api.lua
@@ -31,14 +31,23 @@ end
 
 -- update visuals
 function skins.update_player_skin(player)
-	local skin = skins.get_player_skin(player)
-	skin:set_skin(player)
+	if skins.armor_loaded then
+		-- all needed is wrapped and implemented in 3d_armor mod
+		armor:set_player_armor(player)
+	else
+		-- do updates manually without 3d_armor
+		skins.get_player_skin(player):apply_skin_to_player(player)
+		if minetest.global_exists("sfinv") and sfinv.enabled then
+			sfinv.set_player_inventory_formspec(player)
+		end
+	end
 end
 
--- Assign and update
+-- Assign and update - should be used on selection externally
 function skins.set_player_skin(player, skin)
 	local success = skins.assign_player_skin(player, skin)
 	if success then
+		skins.get_player_skin(player):set_skin(player)
 		skins.update_player_skin(player)
 	end
 	return success

--- a/init.lua
+++ b/init.lua
@@ -32,6 +32,7 @@ end
 
 -- 3d_armor compatibility
 if minetest.global_exists("armor") then
+	skins.armor_loaded = true
 	armor.get_player_skin = function(self, name)
 		local skin = skins.get_player_skin(minetest.get_player_by_name(name))
 		return skin:get_texture()

--- a/skin_meta_api.lua
+++ b/skin_meta_api.lua
@@ -59,8 +59,6 @@ function skin_class:get_preview()
 	return self._preview or "player.png"
 end
 
-local armor_loaded = minetest.global_exists("armor")
-
 function skin_class:apply_skin_to_player(player)
 	local ver = self:get_meta("format") or "1.0"
 	default.player_set_model(player, "skinsdb_3d_armor_character.b3d")
@@ -76,7 +74,7 @@ function skin_class:apply_skin_to_player(player)
 		v10_texture = self:get_texture()
 	end
 
-	if armor_loaded then
+	if skins.armor_loaded then
 		local armor_textures = armor.textures[player:get_player_name()]
 		if armor_textures then
 			armor_texture = armor_textures.armor
@@ -103,7 +101,6 @@ function skin_class:set_skin(player)
 	-- The set_skin is used on skins selection
 	-- This means the method could be redefined to start an furmslec
 	-- See character_creator for example
-	self:apply_skin_to_player(player)
 end
 
 function skin_class:is_applicable_for_player(playername)


### PR DESCRIPTION
(with and without 3d armor)
I had some issues with updates if the selection is done without "set_skin()" fromspec field.At other site updates was done twice.

Now the `skins.update_player_skin(player)` does the visuals update if anything changed (like armor switched) and `skins.set_player_skin(player, skin)` is for update on skin selection, to call the set_skin() hook, used in character_creator to start the character_creator-formspec...

