### PR TITLE
add support for skin names in skin texture file

### DIFF
--- a/textures/readme.txt
+++ b/textures/readme.txt
@@ -1,4 +1,4 @@
 In this folder the skin files could be placed according the next file naming convention
-character_[number].png - Public skin, available for all users
-player_[nick].png or player_[nick]_[number].png - one or multiple private skins for player "nick"
+character_[number-or-name].png - Public skin, available for all users
+player_[nick].png or player_[nick]_[number-or-name].png - one or multiple private skins for player "nick"
 *_preview.png - Preview files for public and private skins


### PR DESCRIPTION
bored to create a metadata file for each skin I reworked the files reading. 

```
character_Skinname_with_spaces.png
character_Skinname_with_spaces_preview.png

player_Playername_Skinname_with_spaces.png
player_Playername_Skinname_with_spaces_preview.png
```
Are shown both as "Skinname with spaces" now in inventory lists.
