### PR TITLE
Update skins_updater.lua for all systems

### DIFF
--- a/skins_updater.lua
+++ b/skins_updater.lua
@@ -75,7 +75,7 @@ end
 
 -- Insecure workaround since meta/ and textures/ cannot be written to
 local function unsafe_file_write(path, contents)
-	local f = ie.io.open(path, "w")
+	local f = ie.io.open(path, "wb")
 	f:write(contents)
 	f:close()
 end


### PR DESCRIPTION
The base64 data from the decoder to the file writer is in binary, using only the "w" flag would work in most unix systems but its incorrect and for all systems with crazy line_feed/Carrier_return or any character conversion the right way to save a binary data is using the "wb" flag.

This will fix the corrupted data for png files in windows systems and locales with character conversions.