### PR TITLE
updater/update_skins.py: Do not download preview files by default

### DIFF
--- a/updater/update_skins.py
+++ b/updater/update_skins.py
@@ -1,5 +1,8 @@
 import sys, requests, base64
 
+download_preview = ( len (sys.argv) > 1 and sys.argv[1] == "with_preview" )
+
+
 print("Downloading skins from minetest.fensta.bplaced.net ...")
 # Requesting all skins and their raw texture using the API
 r = requests.get('http://minetest.fensta.bplaced.net/api/v2/get.json.php?getlist&page=1&per_page=999999999')
@@ -10,35 +13,42 @@ if r.status_code != 200:
 data = r.json()
 count = 0
 
-print("Writing to file and downloading previews ...")
-for json in data["skins"]:
-    id = str(json["id"])
-    # Downloading the preview of the skin
-    r2 = requests.get('http://minetest.fensta.bplaced.net/skins/1/' + id + ".png")
-    if r.status_code == 200:
-        preview = r2.content
-        # Read meta datas
-        name = str(json["name"])
-        author = str(json["author"])
-        license = str(json["license"])
-        # Texture file
-        raw_data = base64.b64decode(json["img"])
-        file = open("../textures/character_" + id + ".png", "wb")
-        file.write(bytearray(raw_data))
-        file.close()
-        # Preview file
-        file = open("../textures/character_" + id + "_preview.png", "wb")
-        file.write(bytearray(preview))
-        file.close()
-        # Meta file
-        file = open("../meta/character_" + id + ".txt", "w")
-        file.write(name + "\n" + author + "\n" + license + "\n")
-        file.close()
-        print("Added #%s Name: %s Author: %s License: %s" % (id, name, author, license))
-        count += 1
+if download_preview:
+    print("Writing to file and downloading previews ...")
+else:
+    print("Writing skins")
 
-    else:
-        print("Failed to download skin #" + id)
+
+for json in data["skins"]:
+    id = str(json["id"]).zfill(4)
+
+    # Texture file
+    raw_data = base64.b64decode(json["img"])
+    file = open("../textures/character_" + id + ".png", "wb")
+    file.write(bytearray(raw_data))
+    file.close()
+
+    # Meta file
+    name = str(json["name"])
+    author = str(json["author"])
+    license = str(json["license"])
+    file = open("../meta/character_" + id + ".txt", "w")
+    file.write(name + "\n" + author + "\n" + license + "\n")
+    file.close()
+    print("Added #%s Name: %s Author: %s License: %s" % (id, name, author, license))
+    count += 1
+
+    if download_preview:
+        # Downloading the preview of the skin
+        r2 = requests.get('http://minetest.fensta.bplaced.net/skins/1/' + id + ".png")
+        if r2.status_code == 200:
+            # Preview file
+            preview = r2.content
+            file = open("../textures/character_" + id + "_preview.png", "wb")
+            file.write(bytearray(preview))
+            file.close()
+        else:
+            print("Failed to download skin preview #" + id)
 
 
 print("Fetched " + str(count) + " skins!")

--- a/updater/update_skins.py
+++ b/updater/update_skins.py
@@ -20,7 +20,7 @@ else:
 
 
 for json in data["skins"]:
-    id = str(json["id"]).zfill(4)
+    id = str(json["id"])
 
     # Texture file
     raw_data = base64.b64decode(json["img"])


### PR DESCRIPTION
Two changes for the python updater script:
1. Add leading zeros to the file names. Fill up to 4 digit characters. Previously the skins are wrong sorted in some cases (1, 11, 111, 1111, 1112 ...) (rejected / removed from PR)
2. The python script does not download the preview files by default anymore. The skinsdb is able to compose the preview using some formspec magic. 
But `python update_skins.py with_preview` still download the preview files as before