### PR TITLE
add hand_monoid support

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -10,4 +10,5 @@ globals = {
 read_globals = {
     string = {fields = {"split", "trim"}},
     table = {fields = {"copy", "getn"}},
+    "hand_monoid",
 }

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = skinsdb
 description = Player skin mod, supporting unified_inventory, sfinv and smart_inventory
 depends = player_api
-optional_depends = unified_inventory,3d_armor,clothing,sfinv
+optional_depends = unified_inventory,3d_armor,clothing,sfinv,hand_monoid
 min_minetest_version = 5.4.0

--- a/skin_meta_api.lua
+++ b/skin_meta_api.lua
@@ -1,5 +1,7 @@
 skins.meta = {}
 
+local has_hand_monoid = minetest.get_modpath("hand_monoid")
+
 local skin_class = {}
 skin_class.__index = skin_class
 skins.skin_class = skin_class
@@ -208,11 +210,19 @@ function skin_class:apply_skin_to_player(player)
 	})
 
 	local hand = self:get_hand()
-	if hand then
-		player:get_inventory():set_size("hand", 1)
-		player:get_inventory():set_stack("hand", 1, hand)
+	if has_hand_monoid then
+		if hand then
+			hand_monoid.monoid:add_change(player, {name = hand}, "skinsdb:hand")
+		else
+			hand_monoid.monoid:del_change(player, "skinsdb:hand")
+		end
 	else
-		player:get_inventory():set_stack("hand", 1, "")
+		if hand then
+			player:get_inventory():set_size("hand", 1)
+			player:get_inventory():set_stack("hand", 1, hand)
+		else
+			player:get_inventory():set_stack("hand", 1, "")
+		end
 	end
 end
 


### PR DESCRIPTION
redo of https://github.com/minetest-mods/skinsdb/pull/72, because i want to create another separate PR and needed to reset master. 

-------------------------------------

add optional support for a mod i created recently to allow multiple mods to control various aspects of the player's hand:

https://github.com/fluxionary/minetest-hand_monoid
