### PR TITLE
add compatibility w/ animations of the emote mod

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -80,6 +80,10 @@ player_api.register_model("skinsdb_3d_armor_character_5.b3d", {
 		mine = {x=189, y=198},
 		walk_mine = {x=200, y=219},
 		sit = {x=81, y=160},
+		-- compatibility w/ the emote mod
+		wave = {x = 192, y = 196, override_local = true},
+		point = {x = 196, y = 196, override_local = true},
+		freeze = {x = 205, y = 205, override_local = true},
 	},
 })
 


### PR DESCRIPTION
currently, when using the emote mod alongside skinsdb, some emotes don't work because they aren't registered w/ the model. this PR adds those animations. 