### PR TITLE
filename seperator setting to fix #54

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,7 +11,7 @@ skins.default = "character"
 -- see skindsdb/textures/readme.txt to avoid playername with underscore problem
 skins.fsep = minetest.settings:get("skinsdb_fsep") or "_"
 if skins.fsep == "_" then
-	minetest.log("warning", "skinsdb filename seperator is set to underscore, see skindsdb/textures/readme.txt to avoid problems with playernames containing underscore")
+	minetest.log("warning", "skinsdb filename seperator is set to " .. skins.fsep .. ", see skindsdb/textures/readme.txt to avoid problems with playernames containing underscore")
 end
 
 dofile(skins.modpath.."/skin_meta_api.lua")

--- a/init.lua
+++ b/init.lua
@@ -8,6 +8,12 @@ skins = {}
 skins.modpath = minetest.get_modpath(minetest.get_current_modname())
 skins.default = "character"
 
+-- see skindsdb/textures/readme.txt to avoid playername with underscore problem
+skins.fsep = minetest.settings:get("skinsdb_fsep") or "_"
+if skins.fsep == "_" then
+	minetest.log("warning", "skinsdb filename seperator is set to underscore, see skindsdb/textures/readme.txt to avoid problems with playernames containing underscore")
+end
+
 dofile(skins.modpath.."/skin_meta_api.lua")
 dofile(skins.modpath.."/api.lua")
 dofile(skins.modpath.."/skinlist.lua")

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,3 @@
+# texture filename seperator, default "_"
+# see skindsdb/README.md to avoid playername with underscore problem
+skinsdb_fsep (texture filename seperator) string _

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,3 +1,3 @@
 # texture filename seperator, default "_"
 # see skindsdb/README.md to avoid playername with underscore problem
-skinsdb_fsep (texture filename seperator) string _
+skinsdb_fsep (texture filename seperator) enum _ _,.

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,3 +1,3 @@
 # texture filename seperator, default "_"
-# see skindsdb/README.md to avoid playername with underscore problem
+# see skindsdb/textures/readme.txt to avoid playername with underscore problem
 skinsdb_fsep (texture filename seperator) enum _ _,.

--- a/skinlist.lua
+++ b/skinlist.lua
@@ -2,7 +2,7 @@ local skins_dir_list = minetest.get_dir_list(skins.modpath.."/textures")
 
 for _, fn in pairs(skins_dir_list) do
 	local name, sort_id, is_preview, playername
-	local nameparts = string.gsub(fn, "[.]", "_"):split("_")
+	local nameparts = string.gsub(fn, "[.]", skins.fsep):split(skins.fsep)
 
 	-- check allowed prefix and file extension
 	if (nameparts[1] == 'player' or nameparts[1] == 'character') and

--- a/skins_updater.lua
+++ b/skins_updater.lua
@@ -88,7 +88,7 @@ local function safe_single_skin(skin)
 		skin.license
 	}
 
-	local name =  "character_" .. skin.id
+	local name =  "character" .. skins.fsep .. skin.id
 
 	-- core.safe_file_write does not work here
 	unsafe_file_write(
@@ -101,7 +101,7 @@ local function safe_single_skin(skin)
 		core.decode_base64(skin.img)
 	)
 	fetch_url(preview_url:format(skin.id), function(preview)
-		unsafe_file_write(skins_path .. name .. "_preview.png", preview)
+		unsafe_file_write(skins_path .. name .. skins.fsep .. "preview.png", preview)
 	end)
 	core.log("action", ("%s: Completed skin %s"):format(_ID_, name))
 end

--- a/textures/readme.txt
+++ b/textures/readme.txt
@@ -1,13 +1,16 @@
 In this folder the skin files could be placed according the following file naming convention.
 
-Notice:
-skinsdb uses an underscore as seperator for filename splitting which can lead to problems with playernames containing "_", see https://github.com/minetest-mods/skinsdb/issues/54.
-To keep compatibility with older versions the config setting skinsdb_fsep (texture filename seperator) with the default value "_" was added as a workaround.
+skinsdb uses an underscore as default seperator for filename splitting which can cause problems with playernames containing "_",
+see https://github.com/minetest-mods/skinsdb/issues/54.
+The config setting skinsdb_fsep (texture filename seperator) was added as a workaround which also offers "."(dot) as seperator,
+dot is the only character which is allowed in textures but not in playernames.
+To keep compatibility with older versions underscore is the default value.
+
 fresh install:
-you should change the seperator to something not allowed in minetest playernames to avoid that problem.
+you should change the seperator to "." to avoid that problem.
 existing install:
-- pick a new seperator and change the filenames according to the naming convention with your seperator instead of the underscore
-- change the seperator in settings or add "skinsdb_fsep = YOURSEPERATOR" to your minetest.conf before starting your server
+- change the filenames according to the naming convention with dot as seperator instead of underscore
+- change the texture filename seperator in settings or add "skinsdb_fsep = ." to your minetest.conf before starting your server
 
 Public skin available for all users:
 	character_[number-or-name].png

--- a/textures/readme.txt
+++ b/textures/readme.txt
@@ -1,5 +1,14 @@
 In this folder the skin files could be placed according the following file naming convention.
 
+Notice:
+skinsdb uses an underscore as seperator for filename splitting which can lead to problems with playernames containing "_", see https://github.com/minetest-mods/skinsdb/issues/54.
+To keep compatibility with older versions the config setting skinsdb_fsep (texture filename seperator) with the default value "_" was added as a workaround.
+fresh install:
+you should change the seperator to something not allowed in minetest playernames to avoid that problem.
+existing install:
+- pick a new seperator and change the filenames according to the naming convention with your seperator instead of the underscore
+- change the seperator in settings or add "skinsdb_fsep = YOURSEPERATOR" to your minetest.conf before starting your server
+
 Public skin available for all users:
 	character_[number-or-name].png
 

--- a/updater/update_skins.py
+++ b/updater/update_skins.py
@@ -1,5 +1,9 @@
 import sys, requests, base64
 
+# filename seperator to use, either default "-" or ".". see skinsdb/textures/readme.txt
+#fsep = "_"
+fsep = "."
+
 download_preview = ( len (sys.argv) > 1 and sys.argv[1] == "with_preview" )
 
 
@@ -24,7 +28,7 @@ for json in data["skins"]:
 
     # Texture file
     raw_data = base64.b64decode(json["img"])
-    file = open("../textures/character_" + id + ".png", "wb")
+    file = open("../textures/character" + fsep + id + ".png", "wb")
     file.write(bytearray(raw_data))
     file.close()
 
@@ -44,7 +48,7 @@ for json in data["skins"]:
         if r2.status_code == 200:
             # Preview file
             preview = r2.content
-            file = open("../textures/character_" + id + "_preview.png", "wb")
+            file = open("../textures/character_" + id + fsep + "preview.png", "wb")
             file.write(bytearray(preview))
             file.close()
         else:


### PR DESCRIPTION
Adds a filename split seperator setting that lets you choose between old style `_` and `.` because dot is the only char that isn´t allowed in playername but in texturenames.
Default value is `_` to keep it compatible with older versions, while `.` offers a solution to fix #54.