### PR TITLE
Remove mesh hand node when player exits

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -63,6 +63,13 @@ end)
 
 minetest.register_on_leaveplayer(function(player)
 	skins.ui_context[player:get_player_name()] = nil
+	player:get_inventory():set_size("hand", 0)
+end)
+
+minetest.register_on_shutdown(function()
+	for _, player in pairs(minetest.get_connected_players()) do
+		player:get_inventory():set_size("hand", 0)
+	end
 end)
 
 player_api.register_model("skinsdb_3d_armor_character_5.b3d", {


### PR DESCRIPTION
When the skinsdb mod is disabled, players who logged in when the mod was enabled get a unknown node hand item. This PR removes the mesh hand node when players exit the game or when the server shuts down.