### PR TITLE
Add migration code to player skins using '.' delimiters

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -2,14 +2,26 @@
 local storage = minetest.get_mod_storage()
 
 function skins.get_player_skin(player)
+	local player_name = player:get_player_name()
 	local meta = player:get_meta()
 	if meta:get("skinsdb:skin_key") then
 		-- Move player data prior July 2018 to mod storage
-		storage:set_string(player:get_player_name(), meta:get_string("skinsdb:skin_key"))
+		storage:set_string(player_name, meta:get_string("skinsdb:skin_key"))
 		meta:set_string("skinsdb:skin_key", "")
 	end
-	local skin = storage:get_string(player:get_player_name())
-	return skins.get(skin) or skins.get(skins.default)
+
+	local skin_name = storage:get_string(player_name)
+	local skin = skins.get(skin_name)
+	if #skin_name > 0 and not skin then
+		-- Migration step to convert `_`-delimited skins to `.` (if possible)
+		skin = skins.__fuzzy_match_skin_name(player_name, skin_name, true)
+		if skin then
+			storage:set_string(player_name, skin:get_key())
+		else
+			storage:set_string(player_name, "")
+		end
+	end
+	return skin or skins.get(skins.default)
 end
 
 -- Assign skin to player

--- a/init.lua
+++ b/init.lua
@@ -112,6 +112,5 @@ minetest.register_allow_player_inventory_action(function(player, action, inv, da
 	end
 end)
 
-if true then
-	dofile(skins.modpath.."/unittest.lua")
-end
+--dofile(skins.modpath.."/unittest.lua")
+

--- a/init.lua
+++ b/init.lua
@@ -111,3 +111,7 @@ minetest.register_allow_player_inventory_action(function(player, action, inv, da
 		return 0
 	end
 end)
+
+if true then
+	dofile(skins.modpath.."/unittest.lua")
+end

--- a/textures/readme.txt
+++ b/textures/readme.txt
@@ -26,7 +26,7 @@ The character `_` is accepted in player names, thus it is not recommended to
 use such file names. For compatibility reasons, they are still recognized.
 
 	character_[number or name].png
-	player_[nick]_png
+	player_[nick].png
 	player_[nick]_[number or name].png
 
 ... and corresponding previews that end in `_preview.png`.

--- a/unittest.lua
+++ b/unittest.lua
@@ -1,0 +1,53 @@
+-- Ensure a best possible compatibility with `_` underscore delimiter weirdnesses
+
+local function get_skin(skin_name)
+	local skin = skins.get(skin_name)
+		or skins.__fuzzy_match_skin_name("(unittest)", skin_name, true)
+	return skin and skin:get_key() or nil
+end
+
+local function run_unittest()
+	local PATH = ":UNITTEST:"
+
+	-- -----
+	-- `.`: Simple register + retrieve operations
+	skins.register_skin(PATH, "player.DotSep.png")
+	skins.register_skin(PATH, "player._DotSep_666_.1.png")
+
+	assert(get_skin("player.DotSep"))
+	assert(get_skin("player._DotSep_666_.1"))
+	assert(get_skin("player.DotSep.1") == nil)
+
+	-- -----
+	-- Ambiguous skin names (filenames without extension). Register + retrieve
+	skins.new("player_AmbSki")
+	skins.new("player_AmbSki_1")
+	skins.new("player_AmbSki_666_1")
+
+	assert(get_skin("player_AmbSki"))
+	assert(get_skin("player_AmbSki_") == nil)
+	assert(get_skin("player_AmbSki_1"))
+	assert(get_skin("player_AmbSki_666_1"))
+	-- There are no `__` patterns as they were silently removed by string.split
+
+
+	-- -----
+	-- Mod Storage backwards compatibility
+	-- Match the old `_` notation to `.`-separated skins
+	skins.register_skin(PATH, "player.ComPat42.png")
+	skins.register_skin(PATH, "player.ComPat42.5.png")
+	skins.register_skin(PATH, "player._Com_Pat_42.png")
+	skins.register_skin(PATH, "player._Com_Pat_42.1.png")
+
+	assert(get_skin("player_ComPat42") == "player.ComPat42")
+	assert(get_skin("player_ComPat42_5") == "player.ComPat42.5")
+	assert(get_skin("player_Com_Pat_42") == "player._Com_Pat_42")
+	assert(get_skin("player_Com_Pat_42_1") == "player._Com_Pat_42.1")
+
+
+	error("Unittest passed! Please disable them now.")
+end
+
+
+--run_unittest()
+

--- a/unittest.lua
+++ b/unittest.lua
@@ -1,5 +1,3 @@
--- Ensure a best possible compatibility with `_` underscore delimiter weirdnesses
-
 local function get_skin(skin_name)
 	local skin = skins.get(skin_name)
 		or skins.__fuzzy_match_skin_name("(unittest)", skin_name, true)
@@ -48,6 +46,6 @@ local function run_unittest()
 	error("Unittest passed! Please disable them now.")
 end
 
-
---run_unittest()
-
+if skins._enable_unittest then
+	run_unittest()
+end

--- a/unittest.lua
+++ b/unittest.lua
@@ -46,6 +46,5 @@ local function run_unittest()
 	error("Unittest passed! Please disable them now.")
 end
 
-if skins._enable_unittest then
-	run_unittest()
-end
+run_unittest()
+


### PR DESCRIPTION
Previously, the players would have their selected skin reset. See 'skins.__fuzzy_match_skin_name' for a detailed explanation.

This also fixes an issue where "player.[name].[number].png" skins were not recognized.

Fixes #101

How to test: modify the mod storage file to use "character_123" or "player_singleplayer_343" skin names but have files named "character.123.png" and "player.singleplayer.343.png".

@Bastrabun Please confirm whether this fixes your issues.