### PR TITLE
Compatibility with Voxelibre

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,6 +5,7 @@ max_line_length = 999
 globals = {
     "minetest", "unified_inventory", "core",
     "player_api", "clothing", "armor", "sfinv",
+    "mcl_skins",
 }
 
 read_globals = {

--- a/api.lua
+++ b/api.lua
@@ -21,6 +21,18 @@ function skins.get_player_skin(player)
 			storage:set_string(player_name, "")
 		end
 	end
+
+	if skins.use_voxelibre_compat then
+		local texture = mcl_skins.player_skins[player].simple_skins_id
+		if texture then
+			for k, listed_skin in pairs(skins.meta) do
+				if listed_skin._texture == texture then
+					return listed_skin
+				end
+			end
+		end
+	end
+
 	return skin or skins.get(skins.default)
 end
 
@@ -46,6 +58,12 @@ function skins.assign_player_skin(player, skin)
 	else
 		return false
 	end
+
+	if skins.use_voxelibre_compat then
+		mcl_skins.player_skins[player].simple_skins_id = skin_obj:get_texture()
+		mcl_skins.save(player)
+	end
+
 	return true, skin_obj
 end
 
@@ -59,6 +77,9 @@ function skins.update_player_skin(player)
 		skins.get_player_skin(player):apply_skin_to_player(player)
 		if minetest.global_exists("sfinv") and sfinv.enabled then
 			sfinv.set_player_inventory_formspec(player)
+		end
+		if skins.use_voxelibre_compat then
+			mcl_skins.update_player_skin(player);
 		end
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -8,6 +8,9 @@ skins = {}
 skins.modpath = minetest.get_modpath(minetest.get_current_modname())
 skins.default = "character"
 
+skins.use_voxelibre_compat = minetest.global_exists("mcl_skins")
+assert(minetest.global_exists("player_api") or minetest.global_exists("mcl_skins"), "One of player_api or mcl_skins is required.")
+
 dofile(skins.modpath.."/skin_meta_api.lua")
 dofile(skins.modpath.."/api.lua")
 dofile(skins.modpath.."/skinlist.lua")
@@ -72,27 +75,29 @@ minetest.register_on_shutdown(function()
 	end
 end)
 
-player_api.register_model("skinsdb_3d_armor_character_5.b3d", {
-	animation_speed = 30,
-	textures = {
-		"blank.png",
-		"blank.png",
-		"blank.png",
-		"blank.png"
-	},
-	animations = {
-		stand = {x=0, y=79},
-		lay = {x=162, y=166},
-		walk = {x=168, y=187},
-		mine = {x=189, y=198},
-		walk_mine = {x=200, y=219},
-		sit = {x=81, y=160},
-		-- compatibility w/ the emote mod
-		wave = {x = 192, y = 196, override_local = true},
-		point = {x = 196, y = 196, override_local = true},
-		freeze = {x = 205, y = 205, override_local = true},
-	},
-})
+if minetest.global_exists("player_api") then
+	player_api.register_model("skinsdb_3d_armor_character_5.b3d", {
+		animation_speed = 30,
+		textures = {
+			"blank.png",
+			"blank.png",
+			"blank.png",
+			"blank.png"
+		},
+		animations = {
+			stand = {x=0, y=79},
+			lay = {x=162, y=166},
+			walk = {x=168, y=187},
+			mine = {x=189, y=198},
+			walk_mine = {x=200, y=219},
+			sit = {x=81, y=160},
+			-- compatibility w/ the emote mod
+			wave = {x = 192, y = 196, override_local = true},
+			point = {x = 196, y = 196, override_local = true},
+			freeze = {x = 205, y = 205, override_local = true},
+		},
+	})
+end
 
 -- Register default character.png if not part of this mod
 local default_skin_obj = skins.get(skins.default)

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,4 @@
 name = skinsdb
 description = Player skin mod, supporting unified_inventory, sfinv and smart_inventory
-depends = player_api
-optional_depends = unified_inventory,3d_armor,clothing,sfinv,hand_monoid
+optional_depends = unified_inventory,3d_armor,clothing,mcl_skins,player_api,sfinv,hand_monoid
 min_minetest_version = 5.4.0

--- a/skin_meta_api.lua
+++ b/skin_meta_api.lua
@@ -159,7 +159,9 @@ function skin_class:apply_skin_to_player(player)
 	local playername = player:get_player_name()
 	local ver = self:get_meta("format") or "1.0"
 
-	player_api.set_model(player, "skinsdb_3d_armor_character_5.b3d")
+	if minetest.global_exists("player_api") then
+		player_api.set_model(player, "skinsdb_3d_armor_character_5.b3d")
+	end
 
 	local v10_texture = "blank.png"
 	local v18_texture = "blank.png"
@@ -195,12 +197,14 @@ function skin_class:apply_skin_to_player(player)
 		end
 	end
 
-	player_api.set_textures(player, {
-			v10_texture,
-			v18_texture,
-			armor_texture,
-			wielditem_texture,
-		})
+	if minetest.global_exists("player_api") then
+		player_api.set_textures(player, {
+				v10_texture,
+				v18_texture,
+				armor_texture,
+				wielditem_texture,
+			})
+	end
 
 	player:set_properties({
 		visual_size = {

--- a/skinlist.lua
+++ b/skinlist.lua
@@ -67,6 +67,10 @@ function skins.register_skin(path, filename)
 		skin_obj._legacy_name = filename_noext:gsub("[._]+", "_")
 	end
 
+	if skins.use_voxelibre_compat then
+		mcl_skins.register_simple_skin({texture = filename})
+	end
+
 	if playername then
 		skin_obj:set_meta("assignment", "player:"..playername)
 		skin_obj:set_meta("playername", playername)


### PR DESCRIPTION
All skins from skinsdb are registered as “simple skins” with mcl_skins, and can be selected using either skindb’s interface or Voxelibre’s own.

Not sure if this is the most elegant way of getting mcl_skins and skinsdb to get along, but it seems to work well enough! ^^