### PR TITLE
Update hand overrides to v5.12.0-dev changes

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = skinsdb
 description = Player skin mod, supporting unified_inventory, sfinv and smart_inventory
 depends = player_api
-optional_depends = unified_inventory,3d_armor,clothing,sfinv,hand_monoid
+optional_depends = unified_inventory, 3d_armor, clothing, creative, sfinv, hand_monoid
 min_minetest_version = 5.4.0


### PR DESCRIPTION
Fixes #113

Luanti commit e037873 changed how the tool range and caps are taken into account. Hence, skin hands now overwrite the long-range hand (`""`) provided by the creative mod. We want to preserve the tool range and capabilities, thus this commit.

Reference https://irc.luanti.org/luanti/2025-03-19#i_6250084

Test results and other feedback is greatly appreciated.