### PR TITLE
remove ie requirement for downloading skins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-textures/character_*.png
-textures/player_*.png
-meta/character_*.txt
-meta/player_*.txt
+textures/character*.png
+textures/player*.png
+meta/character*.txt
+meta/player*.txt

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,6 +5,7 @@ max_line_length = 999
 globals = {
     "minetest", "unified_inventory", "core",
     "player_api", "clothing", "armor", "sfinv",
+    "skins",
 }
 
 read_globals = {

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This Minetest mod offers changeable player skins with a graphical interface for 
 
 #### Ingame Downloader
 
-1) Get Minetest 5.1.0-dev-cb00632 or newer
-2) In the settings menu show advanced options, find the "Developer Options" tab and add "skinsdb" to "Trusted mods" (secure.trusted_mods in minetest.conf)
+1) Get Minetest 5.9.0 or newer
+2) In the settings menu show advanced options, find the "Developer Options" tab and add "skinsdb" to "HTTP mods" (secure.http_mods in minetest.conf)
 3) Start your world
 4) Run `/skinsdb_download_skins <skindb start page> <amount of pages>`
 5) Wait for the Minetest server to shut down

--- a/api.lua
+++ b/api.lua
@@ -74,7 +74,7 @@ function skins.set_player_skin(player, skin)
 	return success
 end
 
--- Check Skin format (code stohlen from stu's multiskin)
+-- Check Skin format (code stolen from stu's multiskin)
 function skins.get_skin_format(file)
 	file:seek("set", 1)
 	if file:read(3) == "PNG" then

--- a/init.lua
+++ b/init.lua
@@ -15,7 +15,7 @@ skins = {}
 skins.modpath = minetest.get_modpath(minetest.get_current_modname())
 skins.default = "character"
 
-local storage_path = core.settings:get("skins.storage_path") or "@MODDATA/skinsdb"
+local storage_path = core.settings:get("skins.storage_path") or "@MODDATA"
 storage_path = storage_path:gsub("^@MODDATA", core.get_mod_data_path())
 storage_path = storage_path:gsub("^@WORLD", core.get_worldpath())
 skins.storage_path = storage_path

--- a/init.lua
+++ b/init.lua
@@ -6,7 +6,11 @@
 
 skins = {}
 skins.modpath = minetest.get_modpath(minetest.get_current_modname())
+skins.storage_path = minetest.get_mod_data_path()
 skins.default = "character"
+
+core.mkdir(skins.storage_path.."/textures")
+core.mkdir(skins.storage_path.."/meta")
 
 dofile(skins.modpath.."/skin_meta_api.lua")
 dofile(skins.modpath.."/api.lua")
@@ -23,9 +27,8 @@ if minetest.get_modpath("sfinv") then
 end
 
 do
-	local ie = minetest.request_insecure_environment()
 	local http = minetest.request_http_api()
-	loadfile(skins.modpath.."/skins_updater.lua")(ie, http)
+	assert(loadfile(skins.modpath.."/skins_updater.lua"))(http)
 end
 
 -- 3d_armor compatibility

--- a/init.lua
+++ b/init.lua
@@ -4,6 +4,13 @@
 -- Rework 2017 by bell07
 -- License: GPLv3
 
+if not core.has_feature({
+    dynamic_add_media_startup = true,
+    dynamic_add_media_filepath = true,
+}) then
+	error("Skinsdb requires Luanti 5.9.0 or newer, please update!")
+end
+
 skins = {}
 skins.modpath = minetest.get_modpath(minetest.get_current_modname())
 skins.default = "character"

--- a/init.lua
+++ b/init.lua
@@ -6,8 +6,12 @@
 
 skins = {}
 skins.modpath = minetest.get_modpath(minetest.get_current_modname())
-skins.storage_path = minetest.get_mod_data_path()
 skins.default = "character"
+
+local storage_path = core.settings:get("skins.storage_path") or "@MODDATA/skinsdb"
+storage_path = storage_path:gsub("^@MODDATA", core.get_mod_data_path())
+storage_path = storage_path:gsub("^@WORLD", core.get_worldpath())
+skins.storage_path = storage_path
 
 core.mkdir(skins.storage_path.."/textures")
 core.mkdir(skins.storage_path.."/meta")

--- a/mod.conf
+++ b/mod.conf
@@ -2,4 +2,4 @@ name = skinsdb
 description = Player skin mod, supporting unified_inventory, sfinv and smart_inventory
 depends = player_api
 optional_depends = unified_inventory, 3d_armor, clothing, creative, sfinv, hand_monoid
-min_minetest_version = 5.4.0
+min_minetest_version = 5.9.0

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,4 @@
 # path to the directory where the skins shall be stored
 # @MODDATA: global storage, path starts at core.get_mod_data_path()
 # @WORLD: per-world storage, path starts at core.get_worldpath()
-skinsdb.storage_path (Storage Path) string @MODDATA/skinsdb
+skinsdb.storage_path (Storage Path) string @MODDATA

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,5 @@
-# path to the directory where the skins shall be stored
-# @MODDATA: global storage, path starts at core.get_mod_data_path()
-# @WORLD: per-world storage, path starts at core.get_worldpath()
+# Path to the directory where the skins shall be stored.
+# The following placeholders can be used:
+#    "@MODDATA": global storage, path starts at core.get_mod_data_path()
+#    "@WORLD": per-world storage, path starts at core.get_worldpath()
 skinsdb.storage_path (Storage Path) string @MODDATA

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,4 @@
+# path to the directory where the skins shall be stored
+# @MODDATA: global storage, path starts at core.get_mod_data_path()
+# @WORLD: per-world storage, path starts at core.get_worldpath()
+skinsdb.storage_path (Storage Path) string @MODDATA/skinsdb

--- a/skinlist.lua
+++ b/skinlist.lua
@@ -139,12 +139,24 @@ function skins.__fuzzy_match_skin_name(player_name, skin_name, be_noisy)
 end
 
 do
-	-- Load skins from the current mod directory
-	local skins_path = skins.modpath.."/textures"
+	-- Load old skins from the current mod directory
+	local legacy_skin_path = skins.modpath.."/textures"
+	local legacy_skins_dir_list = minetest.get_dir_list(legacy_skin_path)
+
+	for _, fn in pairs(legacy_skins_dir_list) do
+		skins.register_skin(legacy_skin_path, fn)
+	end
+
+	-- Load skins
+	local skins_path = skins.storage_path.."/textures"
 	local skins_dir_list = minetest.get_dir_list(skins_path)
 
 	for _, fn in pairs(skins_dir_list) do
-		skins.register_skin(skins_path, fn)
+		if core.dynamic_add_media({
+			filepath = skins_path .. "/" .. fn,
+		}) then
+			skins.register_skin(skins_path, fn)
+		end
 	end
 end
 

--- a/skinlist.lua
+++ b/skinlist.lua
@@ -138,8 +138,9 @@ function skins.__fuzzy_match_skin_name(player_name, skin_name, be_noisy)
 	end
 end
 
+-- Load skins
 do
-	-- Load old skins from the current mod directory
+	-- old skins from the current mod directory
 	local legacy_skin_path = skins.modpath.."/textures"
 	local legacy_skins_dir_list = minetest.get_dir_list(legacy_skin_path)
 
@@ -147,7 +148,7 @@ do
 		skins.register_skin(legacy_skin_path, fn)
 	end
 
-	-- Load skins
+	-- skins as specified by settings
 	local skins_path = skins.storage_path.."/textures"
 	local skins_dir_list = minetest.get_dir_list(skins_path)
 

--- a/skins_updater.lua
+++ b/skins_updater.lua
@@ -1,22 +1,15 @@
 -- Skins update script
 
-local ie, http = ...
+local http = ...
 local S = minetest.get_translator("skinsdb")
 local _ID_ = "Lua Skins Updater"
 
 local internal = {}
 internal.errors = {}
 
--- Binary downloads are required
-if not core.features.httpfetch_binary_data then
-	internal.errors[#internal.errors + 1] =
-		"Feature 'httpfetch_binary_data' is missing. Update Minetest."
-end
-
--- Insecure environment for saving textures and meta
-if not ie or not http then
-	internal.errors[#internal.errors + 1] = "Insecure environment is required. " ..
-		"Please add skinsdb to `secure.trusted_mods` in minetest.conf"
+if not http then
+	internal.errors[#internal.errors + 1] = "http api is required. " ..
+		"Please add skinsdb to `secure.http_mods` in minetest.conf"
 end
 
 minetest.register_chatcommand("skinsdb_download_skins", {
@@ -50,7 +43,7 @@ end
 local root_url = "http://skinsdb.terraqueststudios.net"
 local page_url = root_url .. "/api/v1/content?client=mod&page=%i" -- [1] = Page#
 
-local download_path = skins.modpath
+local download_path = skins.storage_path
 local meta_path = download_path .. "/meta/"
 local skins_path = download_path .. "/textures/"
 
@@ -72,13 +65,6 @@ local function fetch_url(url, callback)
 	end)
 end
 
--- Insecure workaround since meta/ and textures/ cannot be written to
-local function unsafe_file_write(path, contents)
-	local f = ie.io.open(path, "wb")
-	f:write(contents)
-	f:close()
-end
-
 -- Takes a valid skin table from the Skins Database and saves it
 local function save_single_skin(skin)
 	local meta = {
@@ -90,20 +76,20 @@ local function save_single_skin(skin)
 	local name = "character." .. skin.id
 	do
 		local legacy_name = "character_" .. skin.id
-		local fh = ie.io.open(skins_path .. legacy_name .. ".png", "r")
+		local fh = io.open(skins_path .. legacy_name .. ".png", "r")
 		-- Use the old name if either the texture ...
 		if fh then
 			name = legacy_name
+			fh:close()
 		end
 	end
 
-	-- core.safe_file_write does not work here
-	unsafe_file_write(
+	core.safe_file_write(
 		meta_path .. name .. ".txt",
 		table.concat(meta, "\n")
 	)
 
-	unsafe_file_write(
+	core.safe_file_write(
 		skins_path .. name .. ".png",
 		core.decode_base64(skin.img)
 	)


### PR DESCRIPTION
Since the current implementation passes the ie to another file, there are a couple of attack vectors.
The best solution is to simply not use this dangerous feature :-)
- We can store the skins in `core.get_worldpath() .. "/skinsdb"` or `core.get_mod_data_path()` => no ie for reading/writing files needed
- We expose the textures with `core.dynamic_add_media`

~~Added some settings while being on it.~~

#### How to test:
- downloading & equipping skins should still work, skins from before this update should still be around

---

Follow-up PR's I plan, please leave a comment if one the ideas is unlikely to get approved:
- `core.dynamic_add_media` allows to add textures at runtime, there should be no need to kill the server after downloading
- download skins from a user-supplied URL (where `content_type = "image/png"`)
- chatcommand to delete skins again